### PR TITLE
Add new OID for Ruckus wireless SmartZone

### DIFF
--- a/resources/definitions/os_detection/ruckuswireless-sz.yaml
+++ b/resources/definitions/os_detection/ruckuswireless-sz.yaml
@@ -11,6 +11,7 @@ discovery:
     -
         sysObjectID:
             - .1.3.6.1.4.1.25053.3.1.11.1
+            - .1.3.6.1.4.1.25053.3.1.10 #virtual SmartZone
 ignore_mount_string:
     - ruckuswireles
     - etc


### PR DESCRIPTION
For Virual SmartZone (vSZ) - have a new oid.

Added missing `sysObjectID' for correct auto-detection of Ruckus:

    .1.3.6.1.4.1.25053.3.1.10 #virtual SmartZone

Without these OID, devices are identified as 'Generic', and LibreNMS cannot poll their wireless clients, AP and other. 
The changes were tested on real vSmartZone. 
After adding the OID to the file, the definition and survey work correctly.

-     Added OID to the local file ruckuswireless-sz.yaml.
-     The devices have been rediscovered.
-     Devices are now identified as `Ruckus Wireless SmartZone '.
-     The polling of interfaces, traffic graphs, and Wireless Clients, Wireless AP has been verified.



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
