### PR TITLE
Update Xdsl.php

### DIFF
--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -145,6 +145,11 @@ class Xdsl implements Module
         $adslPorts = new Collection;
 
         foreach ($adsl as $ifIndex => $data) {
+            if (!is_array($data)) {
+                Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
+                continue;
+            }
+
             // Values are 1/10
             foreach ($this->adslTenthValues as $oid) {
                 if (isset($data[$oid])) {
@@ -195,6 +200,10 @@ class Xdsl implements Module
         $vdslPorts = new Collection;
 
         foreach ($vdsl as $ifIndex => $data) {
+            if (!is_array($data)) {
+                Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
+                continue;
+            }
             $portVdsl = new PortVdsl([
                 'port_id' => PortCache::getIdFromIfIndex($ifIndex, $os->getDevice()),
                 'xdsl2ChStatusActDataRateXtur' => $data['xdsl2ChStatusActDataRate']['xtur'] ?? 0,


### PR DESCRIPTION
This PR fixes a TypeError in the Xdsl module that occurs when the SNMP response for adslMibObjects or vdsl2LineTable returns data in an unexpected format (e.g., a string instead of an array).  
This usually happens with older or buggy DSLAM implementations (like some my ZTE models). 
Currently, the code passes the $data variable directly into the PortAdsl or PortVdsl constructor without validating that it is an array, leading to a fatal error:TypeError: Illuminate\Database\Eloquent\Model::__construct(): Argument #1 ($attributes) must be of type array, string given.

Changes:Added is_array($data) checks in pollAdsl and pollVdsl methods before model instantiation. Added a warning log when invalid data is received to help with debugging. Testing:Tested with my device returning malformed ADSL SNMP tables. Verified that the discovery/polling process continues for other ports/modules instead of crashing.


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
